### PR TITLE
feat: Add support for static functions

### DIFF
--- a/project/GDExample.gd
+++ b/project/GDExample.gd
@@ -7,6 +7,7 @@ func _ready():
 	set_angry(false)
 	print("Am I angry: " + str(is_angry()))
 	print("Am I happy: " + str(is_happy()))
+	print(GDExample.multiply(5, 7))
 	pass # Replace with function body.
 
 

--- a/source/RegAutomation/Database.cs
+++ b/source/RegAutomation/Database.cs
@@ -9,6 +9,7 @@ namespace RegAutomation
         public class Func
         {
             public List<string> Params = new List<string>();
+            public bool IsStatic = false;
         }
         
         public class Prop

--- a/source/RegAutomation/Pattern_Function.cs
+++ b/source/RegAutomation/Pattern_Function.cs
@@ -26,16 +26,14 @@ namespace RegAutomation
                 // The last token is always the function name
                 string name = tokens[tokens.Length - 1];
                 bool isStatic = false;
-                if(tokens.Length == 3)
+
+                // TODO: Virtual
+                // Use Contains here because static could be before or after the return type
+                if (tokens.Contains("static"))
                 {
-                    // TODO: Virtual
-                    // Use Contains here because static could be before or after the return type
-                    if (tokens.Contains("static"))
-                    {
-                        isStatic = true;
-                    }
+                    isStatic = true;
+                    Console.WriteLine("Registered as static");
                 }
-                else throw new Exception($"Expected two or three tokens but found {tokens.Length}");
                 
                 int paramIndex = content.IndexOf('(') + 1;
                 int paramEndIndex = content.LastIndexOf(')');

--- a/source/RegAutomation/Pattern_Function.cs
+++ b/source/RegAutomation/Pattern_Function.cs
@@ -28,9 +28,9 @@ namespace RegAutomation
                 bool isStatic = false;
                 if(tokens.Length == 3)
                 {
-                    // <static/virtual> <return type> <function name>
                     // TODO: Virtual
-                    if (tokens[0] == "static")
+                    // Use Contains here because static could be before or after the return type
+                    if (tokens.Contains("static"))
                     {
                         isStatic = true;
                     }

--- a/source/RegAutomation/Pattern_Function.cs
+++ b/source/RegAutomation/Pattern_Function.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace RegAutomation
@@ -21,7 +22,20 @@ namespace RegAutomation
                 string sub = type.Value.Content.Substring(startIndex, type.Value.Content.Length - startIndex);
                 string content = sub.Substring(0, sub.IndexOf(';'));
                 string func = content.Substring(0, content.IndexOf('(')).Trim();
-                string name = func.Substring(func.IndexOf(' ') + 1);
+                string[] tokens = func.Split(' ');
+                // The last token is always the function name
+                string name = tokens[tokens.Length - 1];
+                bool isStatic = false;
+                if(tokens.Length == 3)
+                {
+                    // <static/virtual> <return type> <function name>
+                    // TODO: Virtual
+                    if (tokens[0] == "static")
+                    {
+                        isStatic = true;
+                    }
+                }
+                else throw new Exception($"Expected two or three tokens but found {tokens.Length}");
                 
                 int paramIndex = content.IndexOf('(') + 1;
                 int paramEndIndex = content.LastIndexOf(')');
@@ -32,23 +46,27 @@ namespace RegAutomation
                 
                 type.Value.Functions[name] = new DB.Func()
                 {
-                    Params = paramResult
+                    Params = paramResult,
+                    IsStatic = isStatic,
                 };
             }
         }
 
         public static void Generate(KeyValuePair<string, DB.Type> type, ref string content, ref string inject)
         {
-            string bindings = "";
+            var bindings = new StringBuilder();
             foreach (var func in type.Value.Functions)
             {
-                bindings += "ClassDB::bind_method(D_METHOD(\"" + func.Key + "\"";
+                if (func.Value.IsStatic)
+                    bindings.Append($"ClassDB::bind_static_method(\"{type.Value.Name}\", D_METHOD(\"{func.Key}\"");
+                else
+                    bindings.Append($"ClassDB::bind_method(D_METHOD(\"{func.Key}\"");
                 foreach (var param in func.Value.Params)
                     if (param != "")
-                        bindings += ", \"" + param + "\"";
-                bindings += "), &" + type.Value.Name + "::" + func.Key + ");\n\t\t";
+                        bindings.Append($", \"{param}\"");
+                bindings.Append($"), &{type.Value.Name}::{func.Key});\n\t\t");
             }
-            content = content.Replace("REG_BIND_FUNCTIONS", bindings);
+            content = content.Replace("REG_BIND_FUNCTIONS", bindings.ToString());
         }
     }
 }

--- a/source/example_project/GDExample/gdexample.cpp
+++ b/source/example_project/GDExample/gdexample.cpp
@@ -13,3 +13,8 @@ void GDExample::set_var(int var)
     printf("Var: %i\n", var);
 }
 
+double GDExample::multiply(double x, double y)
+{
+    return x * y;
+}
+

--- a/source/example_project/GDExample/gdexample.h
+++ b/source/example_project/GDExample/gdexample.h
@@ -18,6 +18,9 @@ namespace godot
         
         REG_FUNCTION()
         void set_var(int var);
+
+        REG_FUNCTION()
+        static double multiply(double x, double y);
         
         REG_PROPERTY(PROPERTY_HINT_RANGE, "0,20,0.01")
         float property = 0;


### PR DESCRIPTION
This PR uses the `ClassDB::bind_static_method` function to bind static member functions registered under `REG_FUNCTION()`.

In the test code, the C++ static function `GDExample::multiply` is mapped to `GDExample.multiply`.

I've considered adding a second macro `REG_STATIC_FUNCTION`, but this would add a lot of unnecessary code duplication and it's already possible to figure out if a function is static from its declaration anyway, so `REG_FUNCTION()` is reused here.