### PR TITLE
feat: Strip comments from content during parsing

### DIFF
--- a/source/RegAutomation/Database.cs
+++ b/source/RegAutomation/Database.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 
 namespace RegAutomation
 {
@@ -52,9 +53,59 @@ namespace RegAutomation
                     continue;
                 Types[file] = new Type
                 {
-                    Content = content
+                    Content = StripComments(content)
                 };
-            } 
+            }
+        }
+        private static string StripComments(string content)
+        {
+            // Algorithm to remove [// ... \n) and [/* ... */] from content in linear time
+            var result = new StringBuilder();
+            int scanLimit = content.Length;
+            // We look-ahead one char every iteration, so the scan limit should retract by 1
+            scanLimit -= 1;
+            const int SCAN_BEGIN   = 0; // Scan for // or /* (Not in commented section)
+            const int SCAN_NEWLINE = 1; // Scan for \n (In commented section)
+            const int SCAN_STAR    = 2; // Scan for */ (In commented section)
+            int state = SCAN_BEGIN;
+            for (int i = 0; i < scanLimit; ++i)
+            {
+                switch (state)
+                {
+                    case SCAN_BEGIN:
+                        if (content[i] == '/' && content[i + 1] == '/')
+                        {
+                            state = SCAN_NEWLINE;
+                            ++i; // Skip both tokens
+                        }
+                        else if (content[i] == '/' && content[i + 1] == '*')
+                        {
+                            state = SCAN_STAR;
+                            ++i; // Skip both tokens
+                        }
+                        else
+                            result.Append(content[i]);
+                        break;
+                    case SCAN_NEWLINE:
+                        if (content[i] == '\n')
+                        {
+                            state = SCAN_BEGIN;
+                            result.Append(content[i]); // Newlines should be preserved!
+                        }
+                        break;
+                    case SCAN_STAR:
+                        if (content[i] == '*' && content[i + 1] == '/') 
+                        { 
+                            state = SCAN_BEGIN;
+                            ++i; // Skip both tokens
+                        }
+                        break;
+                }
+            }
+            // Get the last char if not in commented section
+            if (state == SCAN_BEGIN) result.Append(content[content.Length - 1]);
+
+            return result.ToString();
         }
     }
 }

--- a/source/example_project/GDExample/gdexample.h
+++ b/source/example_project/GDExample/gdexample.h
@@ -16,10 +16,10 @@ namespace godot
         {
 	        A = 1,
             B = 2,
-            C,
-            D,
+            C, // implicit 3
+            D, // implicit 4
             E = 10,
-            F,
+            F, // implicit 11
         };
     
     public:
@@ -40,6 +40,9 @@ namespace godot
     	bool is_happy;
 
         REG_PROPERTY()
+        /*
+         * (TEST COMMENT)
+         */
     	bool angry;
         
     private:


### PR DESCRIPTION
Previously, inserting comments during sections parsed by a Pattern may cause exceptions (cases like `class /* ... */ ClassName`, and also inserting comments inside enums). While we could modify every Pattern's code to detect comments while parsing, this would lead to a lot of code duplication and isn't very maintainable.

In this PR, I added a comment-stripping function that is used during `DB.Load()` to preprocess file contents and remove both `// ...` and `/* ... */` comments. This simplifies parsing logic and eliminates a lot of edge cases.

Currently it doesn't seem possible yet to add in-editor documentation for GDExtension bound classes/method/etc., so there is no need to parse comments anyway (plus it might also be a better idea to include documentation by passing it into the macro's parameter), but if such a need arises, we could always move the comment-stripping function to the `Pattern` class and let individual Patterns decide which part of the content needs to be comment-stripped.