### PR TITLE
Add support for multiple REG_CLASS in the same header

### DIFF
--- a/project/scene.tscn
+++ b/project/scene.tscn
@@ -13,5 +13,7 @@ script = ExtResource("1_5go6h")
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 5.09969)
 
 [node name="GDInheritanceExample" type="GDInheritanceExample" parent="."]
-is_happy = false
-angry = false
+
+[node name="GDExample2" type="GDExample2" parent="."]
+
+[node name="GDExample3" type="GDExample3" parent="."]

--- a/source/RegAutomation/Database.cs
+++ b/source/RegAutomation/Database.cs
@@ -38,6 +38,7 @@ namespace RegAutomation
 
         public class Header
         {
+            public string IncludeName = ""; // The corresponding generated header's name
             public string Content = "";
             public List<Type> Types = new List<Type>();
         }
@@ -61,6 +62,7 @@ namespace RegAutomation
                     continue;
                 Headers[file] = new Header
                 {
+                    IncludeName = file.Substring(Directory.GetCurrentDirectory().Length + 1).Replace('\\', '.'),
                     Content = content
                 };
             }

--- a/source/RegAutomation/Database.cs
+++ b/source/RegAutomation/Database.cs
@@ -23,19 +23,26 @@ namespace RegAutomation
         {
             public List<(string, int)> KeyValues = new List<(string, int)>();
         }
-
         public class Type
         {
+            public string FileName = "";
             public string Name = "";
             public string Content = "";
             public string ParentName = "";
-            
+            public int RegClassLineNumber = 0;
+
             public Dictionary<string, Func> Functions = new Dictionary<string, Func>();
             public Dictionary<string, Prop> Properties = new Dictionary<string, Prop>();
             public Dictionary<string, Enum> Enums = new Dictionary<string, Enum>();
         }
+
+        public class Header
+        {
+            public string Content = "";
+            public List<Type> Types = new List<Type>();
+        }
         
-        public static Dictionary<string, Type> Types = new Dictionary<string, Type>();
+        public static Dictionary<string, Header> Headers = new Dictionary<string, Header>();
 
         public static void Load()
         {
@@ -52,7 +59,7 @@ namespace RegAutomation
                 string content = File.ReadAllText(file);
                 if (content == "")
                     continue;
-                Types[file] = new Type
+                Headers[file] = new Header
                 {
                     Content = content
                 };

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -97,7 +97,7 @@ namespace RegAutomation
             string include = "";
             foreach (var header in DB.Headers)
                 if (header.Value.Types.Count > 0)
-                    include += $"#include \".generated/{header.Key.Replace('\\', '_').Replace(':', '_')}.generated.h\"\n";
+                    include += $"#include \".generated/{header.Value.IncludeName}.generated.h\"\n";
             return include;
         }
 

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace RegAutomation
@@ -99,16 +100,16 @@ namespace RegAutomation
             return (closureStart, closureEnd);
         }
         
-        public static void GenerateIncludes(KeyValuePair<string, DB.Header> header, ref string content)
+        public static void GenerateIncludes(KeyValuePair<string, DB.Header> header, string content, out string includes)
         {
             includes = $"#include \"{header.Key}\"\n";
         }
         
-        public static void GenerateInject(DB.Type type, ref string inject)
+        public static void GenerateInject(DB.Type type, StringBuilder inject)
         {
-            inject += $"\tGDCLASS({type.Name}, {type.ParentName})\n";
-            inject += "protected: \n";
-            inject += "\tstatic void _bind_methods();\n";
+            inject.Append($"\tGDCLASS({type.Name}, {type.ParentName})\n");
+            inject.Append("protected: \n");
+            inject.Append("\tstatic void _bind_methods();\n");
         }
         
         public static string GetReg()

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -64,14 +64,9 @@ namespace RegAutomation
                 });
             }
         }
-        public static void GenerateIncludes(DB.Header header, ref string content)
+        public static void GenerateIncludes(KeyValuePair<string, DB.Header> header, ref string content)
         {
-            string includes = "";
-            foreach(var type in header.Types)
-            {
-                includes += $"#include \"{type.FileName}\"\n";
-            }
-            content = content.Replace("REG_INCLUDE", includes);
+            content = content.Replace("REG_INCLUDE", $"#include \"{header.Key}\"\n");
         }
         public static void Generate(DB.Type type, ref string content, ref string inject)
         {

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -1,34 +1,39 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace RegAutomation
 {
     public class Pattern_Class : Pattern
     {
-        public static void Process(KeyValuePair<string, DB.Header> header)
+        public static void ProcessHeader(KeyValuePair<string, DB.Header> header)
         {
             MatchCollection matches = FindMatches(header.Value.Content, "REG_CLASS");
             if (matches == null)
                 return;
-            List<int> newlineIndices = new List<int>();
-            for (int i = 0; i < header.Value.Content.Length; ++i)
-                if (header.Value.Content[i] == '\n') newlineIndices.Add(i);
 
+            var newLines = GetNewLines(header.Value.Content);
             int searchStartIndex = 0;
             foreach (Match match in matches)
             {
                 Console.WriteLine("REG_CLASS: " + Path.GetFileName(header.Key));
 
+                // Find next "class" token
+                // // Start searching from the previous REG_CLASS, so multiple classes in same file is possible
                 string search = header.Value.Content.Substring(searchStartIndex, match.Index - searchStartIndex);
                 int classFind = search.LastIndexOf("class ");
                 if (classFind == -1)
                     continue;
-                var classClosure = FindClosure(header.Value.Content, searchStartIndex + classFind);
-                string classContent = header.Value.Content.Substring(classClosure.Item1, classClosure.Item2 - classClosure.Item1);
-                searchStartIndex = match.Index; // Start searching from the previous REG_CLASS, so multiple classes in same file is possible
-                int lineNumber = newlineIndices.BinarySearch(match.Index);
+                
+                // Find class scope
+                var (closureStart, closureEnd) = FindClosure(header.Value.Content, searchStartIndex + classFind);
+                string classContent = header.Value.Content.Substring(closureStart, closureEnd - closureStart);
+                searchStartIndex = match.Index; 
+                
+                // Line number used for code injection 
+                int lineNumber = newLines.BinarySearch(match.Index);
                 if(lineNumber < 0)
                 {
                     // BinarySearch returns the negative of the next-largest element's index
@@ -36,6 +41,8 @@ namespace RegAutomation
                     // it is matched with the first newline, receiving a line number of 0
                     lineNumber = -lineNumber;
                 }
+                
+                // Parse class def
                 string classDef = search.Substring(classFind + "class ".Length);
                 // TODO: Error handling when trying to register a class that doesn't (directly or indirectly) inherit from godot::Object (not supported)
                 // TODO: Detect multiple inheritance (not supported) and throw an exception accordingly
@@ -43,15 +50,11 @@ namespace RegAutomation
                 string nameEnd = classDef.Substring(0, indexOfColon).Trim();
                 string inheritance = classDef.Substring(indexOfColon + 1);
                 string[] tokens = inheritance.Substring(0, inheritance.IndexOf('{'))
-                    .Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 // Assuming no multiple inheritance (not supported anyway), the last space-separated token is the parent class name
                 // Access modifiers like public/protected might appear before the parent class name
                 string parentName = tokens[tokens.Length - 1].Trim();
-                //int startIndex = match.Index + match.Value.Length + 1;
-                //string sub = type.Value.Content.Substring(startIndex, type.Value.Content.Length - startIndex);
-                //string name = sub.Substring(0, sub.IndexOf(')'));
-                //type.Value.Name = name;
-
+                
                 header.Value.Types.Add(new DB.Type() { 
                     FileName = header.Key,
                     Name = nameEnd, 
@@ -61,14 +64,48 @@ namespace RegAutomation
                 });
             }
         }
+        
+        private static List<int> GetNewLines(string content)
+        {
+            List<int> result = new List<int>();
+            for (int i = 0; i < content.Length; ++i)
+                if (content[i] == '\n') 
+                    result.Add(i);
+            return result;
+        }
+        
+        private static (int, int) FindClosure(string content, int startFrom)
+        {
+            int closureCount = 0;
+            int closureStart = startFrom;
+            int closureEnd = -1;
+            for(int i = startFrom; i < content.Length; i++)
+            {
+                if (content[i] == '{') 
+                {
+                    if (closureCount == 0) closureStart = i;
+                    closureCount++; 
+                }
+                else if (content[i] == '}')
+                {
+                    closureCount--;
+                    if (closureCount == 0) 
+                    {
+                        closureEnd = i;
+                        break;
+                    }
+                }
+            }
+            return (closureStart, closureEnd);
+        }
+        
         public static void GenerateIncludes(KeyValuePair<string, DB.Header> header, ref string content)
         {
             content = content.Replace("REG_INCLUDE", $"#include \"{header.Key}\"\n");
         }
-        public static void Generate(DB.Type type, ref string content, ref string inject)
+        
+        public static void GenerateInject(DB.Type type, ref string inject)
         {
-            //content = content.Replace("REG_INCLUDE", "#include \"" + type.FileName + "\"");
-
             inject += $"\tGDCLASS({type.Name}, {type.ParentName})\n";
             inject += "protected: \n";
             inject += "\tstatic void _bind_methods();\n";
@@ -91,32 +128,6 @@ namespace RegAutomation
                 if (header.Value.Types.Count > 0)
                     include += $"#include \".generated/{header.Value.IncludeName}.generated.h\"\n";
             return include;
-        }
-
-        private static (int, int) FindClosure(string content, int startFrom)
-        {
-            int i;
-            int closureCount = 0;
-            int closureStart = startFrom;
-            int closureEnd = -1;
-            for(i = startFrom; i < content.Length; i++)
-            {
-                if (content[i] == '{') 
-                {
-                    if (closureCount == 0) closureStart = i;
-                    closureCount++; 
-                }
-                else if (content[i] == '}')
-                {
-                    closureCount--;
-                    if (closureCount == 0) 
-                    {
-                        closureEnd = i;
-                        break;
-                    }
-                }
-            }
-            return (closureStart, closureEnd);
         }
     }
 }

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -7,48 +7,77 @@ namespace RegAutomation
 {
     public class Pattern_Class : Pattern
     {
-        public static void Process(KeyValuePair<string, DB.Type> type)
+        public static void Process(KeyValuePair<string, DB.Header> header)
         {
-            MatchCollection matches = FindMatches(type.Value.Content, "REG_CLASS");
+            MatchCollection matches = FindMatches(header.Value.Content, "REG_CLASS");
             if (matches == null)
                 return;
+            List<int> newlineIndices = new List<int>();
+            for (int i = 0; i < header.Value.Content.Length; ++i)
+                if (header.Value.Content[i] == '\n') newlineIndices.Add(i);
 
+            int searchStartIndex = 0;
             foreach (Match match in matches)
             {
-                Console.WriteLine("REG_CLASS: " + Path.GetFileName(type.Key));
+                Console.WriteLine("REG_CLASS: " + Path.GetFileName(header.Key));
 
-                string search = type.Value.Content.Substring(0, match.Index);
+                string search = header.Value.Content.Substring(searchStartIndex, match.Index - searchStartIndex);
                 int classFind = search.LastIndexOf("class ");
                 if (classFind == -1)
                     continue;
-
+                var classClosure = FindClosure(header.Value.Content, searchStartIndex + classFind);
+                string classContent = header.Value.Content.Substring(classClosure.Item1, classClosure.Item2 - classClosure.Item1);
+                //Console.WriteLine($"Class Closure: {classContent}");
+                searchStartIndex = match.Index; // Start searching from the previous REG_CLASS, so multiple classes in same file is possible
+                int lineNumber = newlineIndices.BinarySearch(match.Index);
+                if(lineNumber < 0)
+                {
+                    // BinarySearch returns the negative of the next-largest element's index
+                    // if the first newline's at position 42, and REG_CLASS is found at position 20,
+                    // it is matched with the first newline, receiving a line number of 0
+                    lineNumber = -lineNumber;
+                }
                 string classDef = search.Substring(classFind + "class ".Length);
                 // TODO: Error handling when trying to register a class that doesn't (directly or indirectly) inherit from godot::Object (not supported)
                 // TODO: Detect multiple inheritance (not supported) and throw an exception accordingly
                 int indexOfColon = classDef.IndexOf(':');
                 string nameEnd = classDef.Substring(0, indexOfColon).Trim();
-                type.Value.Name = nameEnd;
+                Console.WriteLine("Name: " + nameEnd);
                 string inheritance = classDef.Substring(indexOfColon + 1);
                 string[] tokens = inheritance.Substring(0, inheritance.IndexOf('{'))
                     .Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 // Assuming no multiple inheritance (not supported anyway), the last space-separated token is the parent class name
                 // Access modifiers like public/protected might appear before the parent class name
-                // No need to trim here because we already split on whitespaces
-                string parentName = tokens[tokens.Length - 1];
-                type.Value.ParentName = parentName;
-                
+                string parentName = tokens[tokens.Length - 1].Trim();
+                Console.WriteLine("Inherits from: " + parentName);
                 //int startIndex = match.Index + match.Value.Length + 1;
                 //string sub = type.Value.Content.Substring(startIndex, type.Value.Content.Length - startIndex);
                 //string name = sub.Substring(0, sub.IndexOf(')'));
                 //type.Value.Name = name;
+
+                header.Value.Types.Add(new DB.Type() { 
+                    FileName = header.Key,
+                    Name = nameEnd, 
+                    RegClassLineNumber = lineNumber, 
+                    ParentName = parentName, 
+                    Content = classContent,
+                });
             }
         }
-
-        public static void Generate(KeyValuePair<string, DB.Type> type, ref string content, ref string inject)
+        public static void GenerateIncludes(DB.Header header, ref string content)
         {
-            content = content.Replace("REG_INCLUDE", "#include \"" + type.Key + "\"");
+            string includes = "";
+            foreach(var type in header.Types)
+            {
+                includes += $"#include \"{type.FileName}\"\n";
+            }
+            content = content.Replace("REG_INCLUDE", includes);
+        }
+        public static void Generate(DB.Type type, ref string content, ref string inject)
+        {
+            //content = content.Replace("REG_INCLUDE", "#include \"" + type.FileName + "\"");
 
-            inject += $"\tGDCLASS({type.Value.Name}, {type.Value.ParentName})\n";
+            inject += $"\tGDCLASS({type.Name}, {type.ParentName})\n";
             inject += "protected: \n";
             inject += "\tstatic void _bind_methods();\n";
         }
@@ -56,19 +85,46 @@ namespace RegAutomation
         public static string GetReg()
         {
             string reg = "";
-            foreach (var type in DB.Types)
-                if (type.Value.Name != "")
-                    reg += $"ClassDB::register_class<{type.Value.Name}>();\n";
+            foreach(var keyValue in DB.Headers)
+                foreach (var type in keyValue.Value.Types)
+                    if (type.Name != "")
+                        reg += $"ClassDB::register_class<{type.Name}>();\n";
             return reg; 
         }
 
         public static string GetIncl()
         {
             string include = "";
-            foreach (var type in DB.Types)
-                if (type.Value.Name != "")
-                    include += $"#include \".generated/{type.Value.Name}.generated.h\"\n";
+            foreach (var header in DB.Headers)
+                if (header.Value.Types.Count > 0)
+                    include += $"#include \".generated/{header.Key.Replace('\\', '_').Replace(':', '_')}.generated.h\"\n";
             return include;
+        }
+
+        private static (int, int) FindClosure(string content, int startFrom)
+        {
+            int i;
+            int closureCount = 0;
+            int closureStart = startFrom;
+            int closureEnd = -1;
+            for(i = startFrom; i < content.Length; i++)
+            {
+                if (content[i] == '{') 
+                {
+                    if (closureCount == 0) closureStart = i;
+                    closureCount++; 
+                }
+                else if (content[i] == '}')
+                {
+                    closureCount--;
+                    if (closureCount == 0) 
+                    {
+                        closureEnd = i;
+                        break;
+                    }
+                }
+            }
+            return (closureStart, closureEnd);
         }
     }
 }

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -27,7 +27,6 @@ namespace RegAutomation
                     continue;
                 var classClosure = FindClosure(header.Value.Content, searchStartIndex + classFind);
                 string classContent = header.Value.Content.Substring(classClosure.Item1, classClosure.Item2 - classClosure.Item1);
-                //Console.WriteLine($"Class Closure: {classContent}");
                 searchStartIndex = match.Index; // Start searching from the previous REG_CLASS, so multiple classes in same file is possible
                 int lineNumber = newlineIndices.BinarySearch(match.Index);
                 if(lineNumber < 0)
@@ -42,14 +41,12 @@ namespace RegAutomation
                 // TODO: Detect multiple inheritance (not supported) and throw an exception accordingly
                 int indexOfColon = classDef.IndexOf(':');
                 string nameEnd = classDef.Substring(0, indexOfColon).Trim();
-                Console.WriteLine("Name: " + nameEnd);
                 string inheritance = classDef.Substring(indexOfColon + 1);
                 string[] tokens = inheritance.Substring(0, inheritance.IndexOf('{'))
                     .Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 // Assuming no multiple inheritance (not supported anyway), the last space-separated token is the parent class name
                 // Access modifiers like public/protected might appear before the parent class name
                 string parentName = tokens[tokens.Length - 1].Trim();
-                Console.WriteLine("Inherits from: " + parentName);
                 //int startIndex = match.Index + match.Value.Length + 1;
                 //string sub = type.Value.Content.Substring(startIndex, type.Value.Content.Length - startIndex);
                 //string name = sub.Substring(0, sub.IndexOf(')'));

--- a/source/RegAutomation/Pattern_Comment.cs
+++ b/source/RegAutomation/Pattern_Comment.cs
@@ -5,9 +5,9 @@ namespace RegAutomation
 {
     public class Pattern_Comment : Pattern
     {
-        public static void Process(KeyValuePair<string, DB.Type> type)
+        public static void Process(KeyValuePair<string, DB.Header> header)
         {
-            string content = type.Value.Content;
+            string content = header.Value.Content;
             
             // Algorithm to remove [// ... \n) and [/* ... */] from content in linear time
             var result = new StringBuilder();
@@ -44,7 +44,11 @@ namespace RegAutomation
                     }
                     break;
                 case SCAN_STAR:
-                    if (content[i] == '*' && content[i + 1] == '/') 
+                    if (content[i] == '\n')
+                    {
+                        result.Append(content[i]); // Newlines should be preserved!
+                    }
+                    else if (content[i] == '*' && content[i + 1] == '/') 
                     { 
                         state = SCAN_BEGIN;
                         ++i; // Skip both tokens
@@ -56,10 +60,10 @@ namespace RegAutomation
             if (state == SCAN_BEGIN) 
                 result.Append(content[content.Length - 1]);
 
-            type.Value.Content = result.ToString();
+            header.Value.Content = result.ToString();
         }
 
-        public static void Generate(KeyValuePair<string, DB.Type> type, ref string content, ref string inject)
+        public static void Generate(DB.Type type, ref string content, ref string inject)
         {
             // TODO: Inject comments as documentation
         }

--- a/source/RegAutomation/Pattern_Comment.cs
+++ b/source/RegAutomation/Pattern_Comment.cs
@@ -63,7 +63,7 @@ namespace RegAutomation
             header.Value.Content = result.ToString();
         }
 
-        public static void Generate(DB.Type type, ref string content, ref string inject)
+        public static void Generate(DB.Type type, StringBuilder inject)
         {
             // TODO: Inject comments as documentation
         }

--- a/source/RegAutomation/Pattern_Comment.cs
+++ b/source/RegAutomation/Pattern_Comment.cs
@@ -5,7 +5,7 @@ namespace RegAutomation
 {
     public class Pattern_Comment : Pattern
     {
-        public static void Process(KeyValuePair<string, DB.Header> header)
+        public static void ProcessHeader(KeyValuePair<string, DB.Header> header)
         {
             string content = header.Value.Content;
             
@@ -61,11 +61,6 @@ namespace RegAutomation
                 result.Append(content[content.Length - 1]);
 
             header.Value.Content = result.ToString();
-        }
-
-        public static void Generate(DB.Type type, ref string content, ref string inject)
-        {
-            // TODO: Inject comments as documentation
         }
     }
 }

--- a/source/RegAutomation/Pattern_Enum.cs
+++ b/source/RegAutomation/Pattern_Enum.cs
@@ -8,7 +8,7 @@ namespace RegAutomation
 {
     public class Pattern_Enum : Pattern
     {
-        public static void Process(DB.Type type)
+        public static void ProcessType(DB.Type type)
         {
             MatchCollection matches = FindMatches(type.Content, "REG_ENUM");
             if (matches == null)
@@ -58,7 +58,7 @@ namespace RegAutomation
             {
                 foreach (var (constantName, constantValue) in @enum.Value.KeyValues)
                 {
-                    bindings.Append($"ClassDB::bind_integer_constant(\"{type.Name}\", \"{@enum.Key}\", \"{constantName}\", {constantValue}, false);\n");
+                    bindings.Append($"ClassDB::bind_integer_constant(\"{type.Name}\", \"{@enum.Key}\", \"{constantName}\", {constantValue}, false);\n\t");
                 }
             }
         }

--- a/source/RegAutomation/Pattern_Enum.cs
+++ b/source/RegAutomation/Pattern_Enum.cs
@@ -8,17 +8,17 @@ namespace RegAutomation
 {
     public class Pattern_Enum : Pattern
     {
-        public static void Process(KeyValuePair<string, DB.Type> type)
+        public static void Process(DB.Type type)
         {
-            MatchCollection matches = FindMatches(type.Value.Content, "REG_ENUM");
+            MatchCollection matches = FindMatches(type.Content, "REG_ENUM");
             if (matches == null)
                 return;
 
             foreach (Match match in matches)
             {
-                Console.WriteLine("REG_ENUM: " + Path.GetFileName(type.Key));
+                Console.WriteLine("REG_ENUM: " + Path.GetFileName(type.FileName));
                 int startIndex = match.Value.Length + match.Index + 2;
-                string sub = type.Value.Content.Substring(startIndex, type.Value.Content.Length - startIndex);
+                string sub = type.Content.Substring(startIndex, type.Content.Length - startIndex);
                 string content = sub.Substring(0, sub.IndexOf('}'));
                 string decl = content.Substring(0, content.IndexOf('{'));
                 // Skip "enum " if not anonymous enum, otherwise use "" as name
@@ -48,22 +48,19 @@ namespace RegAutomation
                     }
                 }
                 
-                type.Value.Enums[name] = @enum;
+                type.Enums[name] = @enum;
             }
         }
 
-        public static void Generate(KeyValuePair<string, DB.Type> type, ref string content, ref string inject)
+        public static void GenerateBindings(DB.Type type, StringBuilder bindings)
         {
-            // ClassDB::bind_integer_constant("class", "enum", "constant", <int value>, <bool bitfield>)
-            var bindings = new StringBuilder();
-            foreach(var @enum in type.Value.Enums)
+            foreach (var @enum in type.Enums)
             {
-                foreach(var(constantName, constantValue) in @enum.Value.KeyValues)
+                foreach (var (constantName, constantValue) in @enum.Value.KeyValues)
                 {
-                    bindings.Append($"ClassDB::bind_integer_constant(\"{type.Value.Name}\", \"{@enum.Key}\", \"{constantName}\", {constantValue}, false);\n\t");
+                    bindings.Append($"ClassDB::bind_integer_constant(\"{type.Name}\", \"{@enum.Key}\", \"{constantName}\", {constantValue}, false);\n");
                 }
             }
-            content = content.Replace("REG_BIND_ENUMS", bindings.ToString());
         }
     }
 }

--- a/source/RegAutomation/Pattern_Function.cs
+++ b/source/RegAutomation/Pattern_Function.cs
@@ -9,7 +9,7 @@ namespace RegAutomation
 {
     public class Pattern_Function : Pattern
     {
-        public static void Process(DB.Type type)
+        public static void ProcessType(DB.Type type)
         {
             MatchCollection matches = FindMatches(type.Content, "REG_FUNCTION");
             if (matches == null)
@@ -56,7 +56,7 @@ namespace RegAutomation
                 foreach (var param in func.Value.Params)
                     if (param != "")
                         bindings.Append($", \"{param}\"");
-                bindings.Append($"), &{type.Name}::{func.Key});\n\t\t");
+                bindings.Append($"), &{type.Name}::{func.Key});\n\t");
             }
         }
     }

--- a/source/RegAutomation/Pattern_Property.cs
+++ b/source/RegAutomation/Pattern_Property.cs
@@ -1,27 +1,28 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace RegAutomation
 {
     public class Pattern_Property : Pattern
     {
-        public static void Process(KeyValuePair<string, DB.Type> type)
+        public static void Process(DB.Type type)
         {
-            MatchCollection matches = FindMatches(type.Value.Content, "REG_PROPERTY");
+            MatchCollection matches = FindMatches(type.Content, "REG_PROPERTY");
             if (matches == null)
                 return;
 
             foreach (Match match in matches)
             {
-                Console.WriteLine("REG_PROPERTY: " + Path.GetFileName(type.Key));
+                Console.WriteLine("REG_PROPERTY: " + Path.GetFileName(type.FileName));
 
-                string metaStart = type.Value.Content.Substring(match.Index + match.Value.Length + 1);
+                string metaStart = type.Content.Substring(match.Index + match.Value.Length + 1);
                 string meta = metaStart.Substring(0, metaStart.IndexOf(')'));
                 
                 int startIndex = match.Value.Length + match.Index + meta.Length + 2;
-                string sub = type.Value.Content.Substring(startIndex, type.Value.Content.Length - startIndex);
+                string sub = type.Content.Substring(startIndex, type.Content.Length - startIndex);
                 string content = sub.Substring(0, sub.IndexOf(';')).Trim();
                 var declaration = content.Split(' ');
                 if (declaration.Length < 2)
@@ -31,7 +32,7 @@ namespace RegAutomation
                 }
                 string var = declaration[0];
                 string name = declaration[1];
-                type.Value.Properties[name] = new DB.Prop()
+                type.Properties[name] = new DB.Prop()
                 {
                     Type = var,
                     Meta = meta
@@ -39,12 +40,12 @@ namespace RegAutomation
             }
         }
 
-        public static void Generate(KeyValuePair<string, DB.Type> type, ref string content, ref string inject)
+        public static void GenerateBindings(DB.Type type, StringBuilder bindings, ref string inject)
         {
             string propertyBindings = "";
             string functionBindings = "";
             
-            foreach (var func in type.Value.Properties)
+            foreach (var func in type.Properties)
             {
                 string variant = func.Value.Type.ToUpper();
                 if (variant == "")
@@ -54,7 +55,7 @@ namespace RegAutomation
                 }
                 
                 // Property bindings
-                propertyBindings += $"ClassDB::add_property(\"{type.Value.Name}\", ";
+                propertyBindings += $"ClassDB::add_property(\"{type.Name}\", ";
                 string meta = func.Value.Meta == "" ? "" : $", {func.Value.Meta}"; 
                 propertyBindings += $"PropertyInfo(Variant::{variant}, \"{func.Key}\"{meta}), ";
                 
@@ -69,13 +70,12 @@ namespace RegAutomation
                 // Function bindings
                 // The auto-generated C++ getters and setters still use the get_/set_ prefixes to avoid name collision.
                 functionBindings += $"ClassDB::bind_method(D_METHOD(\"{get}\"), ";
-                functionBindings += $"&{type.Value.Name}::_gen_{get});\n\t";
+                functionBindings += $"&{type.Name}::_gen_{get});\n\t";
                 functionBindings += $"ClassDB::bind_method(D_METHOD(\"{set}\", \"p\"), ";
-                functionBindings += $"&{type.Value.Name}::_gen_{set});\n\t";
+                functionBindings += $"&{type.Name}::_gen_{set});\n\t";
             }
-
-            content = content.Replace("REG_BIND_PROPERTIES", propertyBindings);
-            content = content.Replace("REG_BIND_PROPERTY_FUNCTIONS", functionBindings);
+            bindings.Append(functionBindings);
+            bindings.Append(propertyBindings);
         }
 
         private static (string get, string set) GetGetterSetter(string variant, string property)
@@ -91,5 +91,6 @@ namespace RegAutomation
             }
             return ("get_" + property, "set_" + property);
         }
+
     }
 }

--- a/source/RegAutomation/Pattern_Property.cs
+++ b/source/RegAutomation/Pattern_Property.cs
@@ -40,7 +40,7 @@ namespace RegAutomation
             }
         }
 
-        public static void GenerateBindings(DB.Type type, StringBuilder bindings, ref string inject)
+        public static void GenerateBindings(DB.Type type, StringBuilder bindings, StringBuilder inject)
         {
             string propertyBindings = "";
             string functionBindings = "";
@@ -64,8 +64,8 @@ namespace RegAutomation
                 propertyBindings += $"\"{get}\");\n\t";
 
                 // Function generation
-                inject += "\t" + func.Value.Type + " _gen_" + get + "() const { return " + func.Key + "; }\n";
-                inject += "\tvoid _gen_" + set + "(" + func.Value.Type + " p) { " + func.Key + " = p; }\n";
+                inject.Append("\t" + func.Value.Type + " _gen_" + get + "() const { return " + func.Key + "; }\n");
+                inject.Append("\tvoid _gen_" + set + "(" + func.Value.Type + " p) { " + func.Key + " = p; }\n");
 
                 // Function bindings
                 // The auto-generated C++ getters and setters still use the get_/set_ prefixes to avoid name collision.

--- a/source/RegAutomation/Pattern_Property.cs
+++ b/source/RegAutomation/Pattern_Property.cs
@@ -8,7 +8,7 @@ namespace RegAutomation
 {
     public class Pattern_Property : Pattern
     {
-        public static void Process(DB.Type type)
+        public static void ProcessType(DB.Type type)
         {
             MatchCollection matches = FindMatches(type.Content, "REG_PROPERTY");
             if (matches == null)

--- a/source/RegAutomation/Program.cs
+++ b/source/RegAutomation/Program.cs
@@ -160,7 +160,7 @@ namespace RegAutomation
                     content = content.Replace("REG_INJECT", injects.ToString());
                     content = content.Replace("REG_BIND_CLASS_METHODS", bindClassMethods.ToString());
                     // Write to file
-                    string contentFile = header.Key.Replace('\\', '_').Replace(':', '_') + ".generated.h";
+                    string contentFile = header.Value.IncludeName + ".generated.h";
                     GenerateFile(contentFile, content);
                 }
                 catch (Exception e)

--- a/source/RegAutomation/Program.cs
+++ b/source/RegAutomation/Program.cs
@@ -135,23 +135,17 @@ namespace RegAutomation
                         return;
                     
                     string content = template;
-                    Pattern_Class.GenerateIncludes(header, out string includes);
-                    Pattern_Class.GenerateIncludes(header, ref content);
+                    Pattern_Class.GenerateIncludes(header, content, out string includes);
                     
                     StringBuilder bindClassMethods = new StringBuilder();
                     StringBuilder injects = new StringBuilder();
                     StringBuilder undefs = new StringBuilder();
                     foreach(var type in header.Value.Types)
                     {
-                        StringBuilder inject = new StringBuilder($"#define REG_CLASS{type.RegClassLineNumber}() \n");
+                        StringBuilder inject = new StringBuilder($"#define REG_CLASS_LINE_{type.RegClassLineNumber}() \n");
                         StringBuilder bindings = new StringBuilder();
-                        Pattern_Class.Generate(type, inject);
-                        Pattern_Comment.Generate(type, inject);
-                        string inject = $"#define REG_CLASS_LINE_{type.RegClassLineNumber}() \n";
-                        StringBuilder bindings = new StringBuilder();
-                        
-                        Pattern_Class.GenerateInject(type, ref inject);
-                        
+                        Pattern_Class.GenerateInject(type, inject);
+
                         Pattern_Function.GenerateBindings(type, bindings);
                         Pattern_Enum.GenerateBindings(type, bindings);
                         Pattern_Property.GenerateBindings(type, bindings, inject);

--- a/source/RegAutomation/Program.cs
+++ b/source/RegAutomation/Program.cs
@@ -130,7 +130,7 @@ namespace RegAutomation
                     if (header.Key == "" || header.Value.Types.Count == 0 || header.Value.Content == "")
                         return;
                     string content = template;
-                    Pattern_Class.GenerateIncludes(header.Value, ref content);
+                    Pattern_Class.GenerateIncludes(header, ref content);
                     StringBuilder bindClassMethods = new StringBuilder();
                     StringBuilder injects = new StringBuilder();
                     StringBuilder undefs = new StringBuilder();
@@ -148,10 +148,10 @@ namespace RegAutomation
                         inject += "private: \n";
                         injects.Append(inject);
 
-                        string bindMethod = $"void {type.Name}::_bind_methods()\n{{{bindings}\n}}\n";
+                        string bindMethod = $"void {type.Name}::_bind_methods()\n{{\n{bindings}}}\n";
                         bindClassMethods.Append(bindMethod);
 
-                        string undef = $"#undef REG_CLASS{type.RegClassLineNumber}";
+                        string undef = $"#undef REG_CLASS{type.RegClassLineNumber}\n";
                         undefs.Append(undef);
 
                     }

--- a/source/example_project/GDExample/gdexample.cpp
+++ b/source/example_project/GDExample/gdexample.cpp
@@ -18,3 +18,13 @@ double GDExample::multiply(double x, double y)
     return x * y;
 }
 
+void GDExample2::hello_world()
+{
+    printf("Hello world from GDExample2\n");
+}
+
+void GDExample3::hello_world()
+{
+    printf("Hello world from GDExample3\n");
+}
+

--- a/source/example_project/GDExample/gdexample.h
+++ b/source/example_project/GDExample/gdexample.h
@@ -50,4 +50,50 @@ namespace godot
         double time_passed = 0;
 
     };
+    class GDExample2 : public Node
+    {
+
+        REG_CLASS()
+
+        REG_ENUM()
+        enum Animals
+        {
+            Cat,
+            Dog = 10,
+            Monkey = 17,
+            Giraffe = 20,
+        };
+
+        REG_PROPERTY()
+    	String string_prop = "hi!!!";
+
+    public:
+
+        REG_FUNCTION()
+        void hello_world();
+
+    };
+    class GDExample3 : public Node
+    {
+
+        REG_CLASS()
+
+
+        REG_PROPERTY()
+        int int_prop = 10;
+
+    public:
+        REG_ENUM()
+        enum Fruit
+        {
+            Apple = 17,
+            Orange = 10,
+            Pear = 0,
+            Grape = 78,
+        };
+
+        REG_FUNCTION()
+        void hello_world();
+
+    };
 }

--- a/source/example_project/example_project.vcxproj
+++ b/source/example_project/example_project.vcxproj
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- This vcxproj is based on the automatically generated one in the godot source project -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
   <!-- Configuration -->
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="editor|x64">
@@ -23,7 +22,6 @@
   <ItemGroup>
     <Content Include="reg_class.template" />
   </ItemGroup>
-
   <!-- Globals -->
   <PropertyGroup Label="Globals">
     <ProjectGuid>{426BA961-580F-4B6B-9D56-8BAD4AEF88CD}</ProjectGuid>
@@ -32,14 +30,12 @@
     <VCProjectUpgraderObjectName>NoUpgrade</VCProjectUpgraderObjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-
   <!-- Using make -->
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Makefile</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
-
   <!-- Import cpp symbols -->
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -47,31 +43,23 @@
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  
   <PropertyGroup Label="UserMacros" />
-
   <!-- Make setup -->
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
-
     <!-- The actual commands -->
     <NMakeBuildCommandLine>cmd /V /C &amp;&amp; cd $(SolutionDir) &amp;&amp; build.bat</NMakeBuildCommandLine>
     <NMakeReBuildCommandLine>cmd /V /C &amp;&amp; cd $(SolutionDir) &amp;&amp; rebuild.bat</NMakeReBuildCommandLine>
     <NMakeCleanCommandLine>cmd /V /C &amp;&amp; cd $(SolutionDir) &amp;&amp; clean.bat</NMakeCleanCommandLine>
-
     <!-- Output -->
     <NMakeOutput>$(SolutionDir)..\run.exe</NMakeOutput>
-
     <!-- Temp files -->
     <OutDir>$(SolutionDir).temp\$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir).temp\</IntDir>
-
     <!-- Preprocessor definitions -->
     <NMakePreprocessorDefinitions>TOOLS_ENABLED;DEBUG_ENABLED;NDEBUG;NO_EDITOR_SPLASH;WINDOWS_ENABLED;WASAPI_ENABLED;WINMIDI_ENABLED;TYPED_METHOD_BIND;WIN32;WINVER=0x0601;_WIN32_WINNT=0x0601;NOMINMAX;_WIN64;VULKAN_ENABLED;GLES3_ENABLED;_HAS_EXCEPTIONS=0;MINIZIP_ENABLED;BROTLI_ENABLED;CLIPPER2_ENABLED;ZSTD_STATIC_LINKING_ONLY;USE_VOLK;VK_USE_PLATFORM_WIN32_KHR;GLAD_ENABLED;EGL_ENABLED</NMakePreprocessorDefinitions>
-
     <!-- Includes -->
     <NMakeIncludeSearchPath>$(SolutionDir)\..\godot-cpp\include\;$(SolutionDir)\..\godot-cpp\gen\include\;$(SolutionDir)\..\godot-cpp\gdextension\</NMakeIncludeSearchPath>
-
     <!-- Misc-->
     <NMakeForcedIncludes>$(NMakeForcedIncludes)</NMakeForcedIncludes>
     <NMakeAssemblySearchPath>$(NMakeAssemblySearchPath)</NMakeAssemblySearchPath>
@@ -83,7 +71,6 @@
     <NMakeOutput>$(SolutionDir)..\godot.exe</NMakeOutput>
     <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(SolutionDIr)</IncludePath>
   </PropertyGroup>
-  
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/source/example_project/reg_class.template
+++ b/source/example_project/reg_class.template
@@ -1,4 +1,5 @@
-
+#undef REG_CLASS_INTERNAL_HIDE
+#define REG_CLASS_INTERNAL_HIDE(x) x
 REG_INJECT
 
 #pragma once
@@ -9,10 +10,6 @@ REG_INCLUDE
 
 using namespace godot;
 
-void REG_CLASS_NAME::_bind_methods() 
-{
-    REG_BIND_FUNCTIONS
-    REG_BIND_PROPERTY_FUNCTIONS
-    REG_BIND_PROPERTIES
-    REG_BIND_ENUMS
-}
+REG_UNDEF
+
+REG_BIND_CLASS_METHODS

--- a/source/example_project/registration.h
+++ b/source/example_project/registration.h
@@ -39,7 +39,10 @@
  */
 #define REG_SIGNAL()
 
-// This is used to REG_CLASS() to REG_CLASS<line number>()
+
+
+// Internal macros, do not use!
+// REG_CLASS() -> REG_CLASS_LINE_<line number>()
 #define REG_CLASS_INTERNAL_HIDE(x)
-#define REG_CLASS_INTERNAL_CONCAT(x) REG_CLASS ## x()
+#define REG_CLASS_INTERNAL_CONCAT(x) REG_CLASS_LINE_ ## x()
 #define REG_CLASS_INTERNAL(x) REG_CLASS_INTERNAL_CONCAT(x)

--- a/source/example_project/registration.h
+++ b/source/example_project/registration.h
@@ -5,7 +5,7 @@
 /**
  * Replace GDCLASS(name, parent) with #include REG_CLASS()
  */
-#define REG_CLASS(...) 
+#define REG_CLASS(...) REG_CLASS_INTERNAL_HIDE(REG_CLASS_INTERNAL(__LINE__))
 
 /**
  * Usage:
@@ -38,3 +38,8 @@
  * TODO:
  */
 #define REG_SIGNAL()
+
+#define REG_CLASS_MACRO_IMPL
+#define REG_CLASS_INTERNAL_HIDE(x)
+#define REG_CLASS_INTERNAL_CONCAT(x) REG_CLASS ## x()
+#define REG_CLASS_INTERNAL(x) REG_CLASS_INTERNAL_CONCAT(x)

--- a/source/example_project/registration.h
+++ b/source/example_project/registration.h
@@ -39,7 +39,7 @@
  */
 #define REG_SIGNAL()
 
-#define REG_CLASS_MACRO_IMPL
+// This is used to REG_CLASS() to REG_CLASS<line number>()
 #define REG_CLASS_INTERNAL_HIDE(x)
 #define REG_CLASS_INTERNAL_CONCAT(x) REG_CLASS ## x()
 #define REG_CLASS_INTERNAL(x) REG_CLASS_INTERNAL_CONCAT(x)


### PR DESCRIPTION
This PR addresses the issue of the codegen not supporting multiple `REG_CLASS` in the same header by using `__LINE__` macros to differentiate different REG_CLASS instances. A lot of refactoring (including a new `DB.Header` class that contains one or more `DB.Type`) is introduced to achieve this.

The refactoring would also make implementing the fix proposed in #8 much easier, now that headers are represented by an explicit data structure.

---

The core of this PR lies in the new `REG_CLASS`:
```
#define REG_CLASS_INTERNAL_HIDE(x)
#define REG_CLASS_INTERNAL_CONCAT(x) REG_CLASS ## x()
#define REG_CLASS_INTERNAL(x) REG_CLASS_INTERNAL_CONCAT(x)
#define REG_CLASS(...) REG_CLASS_INTERNAL_HIDE(REG_CLASS_INTERNAL(__LINE__))
```

This magical macro transforms every `REG_CLASS()` into `REG_CLASS<line number>()` (for example, `REG_CLASS12()` would be a `REG_CLASS()` on line 12 in its header), which can then be matched with generated `#define`s inserted in `REG_INJECT`. As this would normally result in illegal syntax before the matching defines are inserted, `REG_CLASS_INTERNAL_HIDE` is used to turn `REG_CLASS<line number>()` into transparent no-ops, and in the template file `#define REG_CLASS_INTERNAL_HIDE(x) x` is inserted to disable this hiding behavior.

`reg_class.template` has also been modified heavily. There is no longer a hard-coded `_bind_methods` in the template. In its stead is the injection point `REG_BIND_CLASS_METHODS`, which is used to insert `_bind_methods` for each registered class in the header. In the future it might be a good idea to just remove the template file altogether,, making the codegen easier to read.

In `Pattern_Comment`, a minor modification is added to preserve newlines when stripping comments. This makes line numbers consistent, which is important as we need to keep track of line numbers ourselves.

`DB.Type` now has a `RegClassLineNumber` property, which is tracked and assigned by `Pattern_Class` and is used to create matching `#define REG_CLASS<line number>()` statements.
