### PR TITLE
Add support for bitfields

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Here is how to use them:
  * ``REG_FUNCTION()`` - Put this in front of your function.
  * ``REG_PROPERTY()`` - Put this in front of your property. Supports ``PropertyInfo`` meta parameters.
  * ``REG_ENUM()`` - Put this in front of your enum.
+ * ``REG_BITFIELD()`` - Like ``REG_ENUM``, but your enum will be treated as flags in the editor.
 
 There is an example class called GDExample that you can use for reference. 
 Registration-code will be injected into ``extension.cpp``. Class bindings will be generated based on ``reg_class.template``. 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Here is how to use them:
  * ``REG_FUNCTION()`` - Put this in front of your function.
  * ``REG_PROPERTY()`` - Put this in front of your property. Supports ``PropertyInfo`` meta parameters.
  * ``REG_ENUM()`` - Put this in front of your enum.
- * ``REG_BITFIELD()`` - Like ``REG_ENUM``, but your enum will be treated as flags in the editor.
 
 There is an example class called GDExample that you can use for reference. 
 Registration-code will be injected into ``extension.cpp``. Class bindings will be generated based on ``reg_class.template``. 

--- a/source/RegAutomation/Database.cs
+++ b/source/RegAutomation/Database.cs
@@ -21,7 +21,8 @@ namespace RegAutomation
 
         public class Enum
         {
-            public List<(string, int)> KeyValues = new List<(string, int)>();
+            public List<string> Keys = new List<string>();
+            public bool IsBitField = false;
         }
         public class Type
         {

--- a/source/RegAutomation/Pattern.cs
+++ b/source/RegAutomation/Pattern.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace RegAutomation
@@ -18,6 +20,57 @@ namespace RegAutomation
                 Console.WriteLine(e);
             }
             return null;
+        }
+        protected static Dictionary<string, string> FindMetaProperties(string content, int searchStartIndex)
+        {
+            Dictionary<string, string> properties = new Dictionary<string, string>();
+            int level = 0;
+            List<int> propertySeparatorIndices = new List<int>();
+            for(int i = searchStartIndex; i < content.Length; i++)
+            {
+                if(level > 0)
+                {
+                    if (level == 1 && content[i] == ',')
+                    {
+                        propertySeparatorIndices.Add(i);
+                    }
+                }
+                if (content[i] == '(')
+                {
+                    if (level == 0) 
+                    {
+                        propertySeparatorIndices.Add(i);
+                    }
+                    level++;
+                }
+                else if (content[i] == ')')
+                {
+                    level--;
+                    if (level == 0) 
+                    {
+                        propertySeparatorIndices.Add(i);
+                        break;
+                    }
+                }
+            }
+            for(int i = 0; i < propertySeparatorIndices.Count - 1; i++)
+            {
+                int start = propertySeparatorIndices[i] + 1; // Skip the '(' or ','
+                int end = propertySeparatorIndices[i + 1]; // Skip the ')' or ','
+                string property = content.Substring(start, end - start).Trim();
+                var split = property.Split('=');
+                if (split.Length == 2) // <key> = <value>
+                {
+                    properties[split[0].Trim()] = split[1].Trim();
+                }
+                else if (split.Length < 2) // <key>
+                {
+                    properties[split[0].Trim()] = "";
+                }
+                else throw new Exception("Illegal meta property syntax detected.");
+            }
+
+            return properties;
         }
     }
 }

--- a/source/RegAutomation/Pattern.cs
+++ b/source/RegAutomation/Pattern.cs
@@ -24,12 +24,14 @@ namespace RegAutomation
         protected static Dictionary<string, string> FindMetaProperties(string content, int searchStartIndex)
         {
             Dictionary<string, string> properties = new Dictionary<string, string>();
+            // First, find property separator indices so we know the intervals where properties are
             int level = 0;
             List<int> propertySeparatorIndices = new List<int>();
             for(int i = searchStartIndex; i < content.Length; i++)
             {
                 if(level > 0)
                 {
+                    // Don't do nested properties here. Let callers decide what to do with them (e.g., pass them verbatim like PropertyInfos)
                     if (level == 1 && content[i] == ',')
                     {
                         propertySeparatorIndices.Add(i);
@@ -53,6 +55,7 @@ namespace RegAutomation
                     }
                 }
             }
+            // Then, we retrieve every substring defined by the intervals.
             for(int i = 0; i < propertySeparatorIndices.Count - 1; i++)
             {
                 int start = propertySeparatorIndices[i] + 1; // Skip the '(' or ','

--- a/source/RegAutomation/Pattern_Enum.cs
+++ b/source/RegAutomation/Pattern_Enum.cs
@@ -38,9 +38,11 @@ namespace RegAutomation
             var @enum = new DB.Enum();
             foreach (string enumDecl in enumContent.Split(','))
             {
-                if (enumDecl.Trim().Length == 0) continue;
+                if (enumDecl.Trim().Length == 0) 
+                    continue;
                 string[] tokens = enumDecl.Split('=');
-                if (tokens.Length == 0) continue;
+                if (tokens.Length == 0) 
+                    continue;
                 @enum.Keys.Add(tokens[0].Trim());
             }
             @enum.IsBitField = asBitField;

--- a/source/RegAutomation/Pattern_Enum.cs
+++ b/source/RegAutomation/Pattern_Enum.cs
@@ -10,43 +10,33 @@ namespace RegAutomation
     {
         public static void ProcessType(DB.Type type)
         {
-            MatchCollection enumMatches = FindMatches(type.Content, "REG_ENUM");
-            if (enumMatches != null)
-                foreach (Match match in enumMatches)
-                {
-                    Console.WriteLine("REG_ENUM: " + Path.GetFileName(type.FileName));
-                    ProcessEnum(type, match, false);
-                }
-            MatchCollection bitFieldMatches = FindMatches(type.Content, "REG_BITFIELD");
-            if(bitFieldMatches != null)
-                foreach (Match match in bitFieldMatches)
-                {
-                    Console.WriteLine("REG_BITFIELD: " + Path.GetFileName(type.FileName));
-                    ProcessEnum(type, match, true);
-                }
-        }
-
-        private static void ProcessEnum(DB.Type type, Match match, bool asBitField)
-        {
-            int startIndex = match.Value.Length + match.Index + 2;
-            string sub = type.Content.Substring(startIndex, type.Content.Length - startIndex);
-            string content = sub.Substring(0, sub.IndexOf('}'));
-            string decl = content.Substring(0, content.IndexOf('{'));
-            // Skip "enum " if not anonymous enum, otherwise use "" as name
-            string name = decl.Contains("enum ") ? decl.Substring(decl.IndexOf("enum ") + 5).Trim() : "";
-            string enumContent = content.Substring(content.IndexOf('{') + 1);
-            var @enum = new DB.Enum();
-            foreach (string enumDecl in enumContent.Split(','))
+            MatchCollection matches = FindMatches(type.Content, "REG_ENUM");
+            if (matches == null)
+                return;
+            foreach (Match match in matches)
             {
-                if (enumDecl.Trim().Length == 0) 
-                    continue;
-                string[] tokens = enumDecl.Split('=');
-                if (tokens.Length == 0) 
-                    continue;
-                @enum.Keys.Add(tokens[0].Trim());
+                Console.WriteLine("REG_ENUM: " + Path.GetFileName(type.FileName));
+                int startIndex = match.Value.Length + match.Index + 2;
+                string sub = type.Content.Substring(startIndex, type.Content.Length - startIndex);
+                string content = sub.Substring(0, sub.IndexOf('}'));
+                string decl = content.Substring(0, content.IndexOf('{'));
+                // Skip "enum " if not anonymous enum, otherwise use "" as name
+                string name = decl.Contains("enum ") ? decl.Substring(decl.IndexOf("enum ") + 5).Trim() : "";
+                string enumContent = content.Substring(content.IndexOf('{') + 1);
+                var @enum = new DB.Enum();
+                foreach (string enumDecl in enumContent.Split(','))
+                {
+                    if (enumDecl.Trim().Length == 0)
+                        continue;
+                    string[] tokens = enumDecl.Split('=');
+                    if (tokens.Length == 0)
+                        continue;
+                    @enum.Keys.Add(tokens[0].Trim());
+                }
+                Dictionary<string, string> metaProperties = FindMetaProperties(type.Content, match.Index);
+                @enum.IsBitField = metaProperties.ContainsKey("REG_P_Bitfield");
+                type.Enums[name] = @enum;
             }
-            @enum.IsBitField = asBitField;
-            type.Enums[name] = @enum;
         }
 
         public static void GenerateBindings(DB.Type type, StringBuilder bindings)

--- a/source/example_project/GDExample/gdexample.h
+++ b/source/example_project/GDExample/gdexample.h
@@ -55,7 +55,7 @@ namespace godot
 
         REG_CLASS()
 
-        REG_BITFIELD()
+        REG_ENUM(REG_P_Bitfield)
         enum Animals
         {
             Cat = 1,

--- a/source/example_project/GDExample/gdexample.h
+++ b/source/example_project/GDExample/gdexample.h
@@ -55,13 +55,13 @@ namespace godot
 
         REG_CLASS()
 
-        REG_ENUM()
+        REG_BITFIELD()
         enum Animals
         {
-            Cat,
-            Dog = 10,
-            Monkey = 17,
-            Giraffe = 20,
+            Cat = 1,
+            Dog = 1 << 1,
+            Monkey = 1 << 2,
+            Giraffe = 1 << 3,
         };
 
         REG_PROPERTY()

--- a/source/example_project/registration.h
+++ b/source/example_project/registration.h
@@ -21,18 +21,22 @@
  */
 #define REG_PROPERTY(...)
 
- /**
-  * Usage:
-  * REG_ENUM()
-  * enum MyEnum
-  *	{
-  *		EntryA,
-  *		EntryB = 5,
-  *		EntryC,
-  *		EntryD = 15
-  *	}
-  */
+/**
+* Usage:
+* REG_ENUM()
+* enum MyEnum
+*	{
+*		EntryA,
+*		EntryB = 5,
+*		EntryC,
+*		EntryD = 15
+*	}
+*/
 #define REG_ENUM(...)
+/**
+ * Usage: Same as REG_ENUM
+ */
+#define REG_BITFIELD(...)
 
 /*
  * TODO:

--- a/source/example_project/registration.h
+++ b/source/example_project/registration.h
@@ -33,10 +33,11 @@
 *	}
 */
 #define REG_ENUM(...)
-/**
- * Usage: Same as REG_ENUM
- */
-#define REG_BITFIELD(...)
+enum REG_ENUM_PROPERTIES
+{
+	// If passed into REG_ENUM, interpret the enum as a Godot bitfield.
+	REG_P_Bitfield,
+};
 
 /*
  * TODO:


### PR DESCRIPTION
This PR adds support for marking C++ enums as Godot bitfields. using the `REG_BITFIELD()` macro.