### PR TITLE
Add proper support for multiple REG_CLASS headers

### DIFF
--- a/source/RegAutomation/Database.cs
+++ b/source/RegAutomation/Database.cs
@@ -38,6 +38,7 @@ namespace RegAutomation
             public string IncludeName = ""; // The corresponding generated header's name
             public string Content = "";
             public List<Type> Types = new List<Type>();
+            public List<string> Includes = new List<string>(); 
         }
         
         public static Dictionary<string, Header> Headers = new Dictionary<string, Header>();

--- a/source/RegAutomation/Pattern_Class.cs
+++ b/source/RegAutomation/Pattern_Class.cs
@@ -96,11 +96,6 @@ namespace RegAutomation
             return (closureStart, closureEnd);
         }
         
-        public static void GenerateIncludes(KeyValuePair<string, DB.Header> header, string content, out string includes)
-        {
-            includes = $"#include \"{header.Key}\"\n";
-        }
-        
         public static void GenerateInject(DB.Type type, StringBuilder inject)
         {
             inject.Append($"\tGDCLASS({type.Name}, {type.ParentName})\n");
@@ -116,16 +111,6 @@ namespace RegAutomation
                     if (type.Name != "")
                         reg += $"ClassDB::register_class<{type.Name}>();\n";
             return reg; 
-        }
-
-        public static string GetIncl()
-        {
-            // TODO: Compute the correct include sequence to avoid compilation errors
-            string include = "";
-            foreach (var header in DB.Headers)
-                if (header.Value.Types.Count > 0)
-                    include += $"#include \".generated/{header.Value.IncludeName}.generated.h\"\n";
-            return include;
         }
     }
 }

--- a/source/RegAutomation/Pattern_Include.cs
+++ b/source/RegAutomation/Pattern_Include.cs
@@ -15,7 +15,7 @@ namespace RegAutomation
         {
             // This pattern matches "#include<zero or more whitespaces><opening quotation mark>"
             // Example: #include "MyNode.h", #include"TestNode.h"
-            MatchCollection matches = FindMatches(header.Value.Content, "#include\\s*\"");
+            MatchCollection matches = Regex.Matches(header.Value.Content, "#include\\s*\"");
             if (matches == null)
             {
                 Console.WriteLine("No include found");

--- a/source/RegAutomation/Pattern_Include.cs
+++ b/source/RegAutomation/Pattern_Include.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using static RegAutomation.DB;
+
+namespace RegAutomation
+{
+    public class Pattern_Include : Pattern
+    {
+        public static void ProcessHeader(KeyValuePair<string, DB.Header> header)
+        {
+            // This pattern matches "#include<zero or more whitespaces><opening quotation mark>"
+            // Example: #include "MyNode.h", #include"TestNode.h"
+            MatchCollection matches = FindMatches(header.Value.Content, "#include\\s*\"");
+            if (matches == null)
+            {
+                Console.WriteLine("No include found");
+                return;
+            }
+            foreach (Match match in matches)
+            {
+                int includePathStart = match.Index + match.Length; // Starts after the opening quotating mark.
+                int includePathEnd = header.Value.Content.IndexOf('\"', includePathStart);
+                if(includePathEnd < 0 )
+                {
+                    throw new Exception("Closing quotation mark not found in include statement.");
+                }
+                string includePath = header.Value.Content.Substring(includePathStart, includePathEnd - includePathStart).Replace('/', '\\');
+                // TODO: Find a way to share ignore list with DB.Load.
+                if (includePath.Contains("\\registration.h"))
+                    continue;
+                // Find this header's directory so we can convert relative filepaths to absolute filepaths.
+                int currentDirectoryEndIndex = header.Key.LastIndexOf('\\');
+                if(currentDirectoryEndIndex >= 0)
+                {
+                    includePath = $"{header.Key.Substring(0, currentDirectoryEndIndex)}\\{includePath}";
+                }
+                if (!DB.Headers.ContainsKey(includePath))
+                {
+                    throw new Exception($"Include path {includePath} wasn't picked up by the Database!");
+                }
+                header.Value.Includes.Add(includePath);
+            }
+        }
+
+        public static void GenerateIncludes(KeyValuePair<string, DB.Header> header, string content, out string includes)
+        {
+            includes = $"#include \"{header.Key}\"\n";
+        }
+
+        public static string GetIncl()
+        {
+            // Step 1: Linearize all headers into a zero-based index.
+            // This maintains the mapping from indices to database headers.
+            List<DB.Header> indexToHeader = new List<DB.Header>();
+            // This maintains the mapping from header filepaths to indices.
+            Dictionary<string, int> keyToIndex = new Dictionary<string, int>();
+            // This maintains every header's dependency, which can change during the algorithm.
+            List<List<int>> indexToDependency = new List<List<int>>();
+            foreach (var header in DB.Headers)
+            {
+                int index = indexToHeader.Count;
+                indexToHeader.Add(header.Value);
+                keyToIndex[header.Key] = index;
+                indexToDependency.Add(new List<int>());
+            }
+            for(int i = 0; i < indexToHeader.Count; i++) 
+            {
+                var header = indexToHeader[i];
+                foreach(var dependency in header.Includes)
+                {
+                    int depIndex = keyToIndex[dependency];
+                    indexToDependency[i].Add(depIndex);
+                }
+            }
+            // Step 2: Find reg class dependencies for every reg class header.
+            // We update indexToDependency here to limit the scope to reg class headers.
+            // Note: Worst case O(N^2) (quadratic to total header count), but should practically never happen.
+            // TODO: Come up with an algorithm that has a better worst-case time complexity.
+            // A list of reg class headers.
+            List<int> regClassHeaderIndices = new List<int>();
+            // Keeps track of visited headers during depth-first search.
+            List<bool> visited = new List<bool>();
+            // Keeps track of how many reg class headers include this header.
+            // Not actually used for non-reg class headers, but their spots are reserved for O(1) indexing.
+            List<int> regClassIncludedCount = new List<int>();
+            // Step 2.1: Initialization.
+            for (int i = 0; i < indexToHeader.Count; i++)
+            {
+                if (indexToHeader[i].Types.Count > 0)
+                    regClassHeaderIndices.Add(i);
+                visited.Add(false);
+                regClassIncludedCount.Add(0);
+            }
+            // Step 2.2: Recursively search for reg class headers and
+            // update dependencies to only contain reg class headers.
+            foreach (int index in regClassHeaderIndices)
+            {
+                if (indexToHeader[index].Types.Count == 0) continue;
+                List<int> updatedDependency = new List<int>();
+                RecursiveFindRegClassDependency(index, updatedDependency);
+                foreach (int depIndex in updatedDependency)
+                    regClassIncludedCount[depIndex]++;
+                indexToDependency[index] = updatedDependency;
+            }
+            // Find immediate reg class headers and add them to the updatedDependency list.
+            // "Immediate" means no other reg class headers between it and the source reg class header.
+            void RecursiveFindRegClassDependency(int currentIndex, List<int> updatedDependency)
+            {
+                if (visited[currentIndex]) 
+                    return;
+                visited[currentIndex] = true;
+                foreach(int depIndex in indexToDependency[currentIndex])
+                {
+                    if (indexToHeader[depIndex].Types.Count > 0)
+                        updatedDependency.Add(depIndex);
+                    else
+                        RecursiveFindRegClassDependency(depIndex, updatedDependency);
+                }
+                visited[currentIndex] = false;
+            }
+            // Step 3: Find topological ordering of reg class headers.
+            // Kahn's algorithm is used here.
+            List<int> topologicalOrder = new List<int>();
+            Queue<int> searchQueue = new Queue<int>();
+            // Step 3.1: Find all reg class headers that aren't included by other headers.
+            // Our search always starts from such headers.
+            foreach (int index in regClassHeaderIndices)
+            {
+                if (regClassIncludedCount[index] == 0) 
+                    searchQueue.Enqueue(index);
+            }
+            // Step 3.2: Keep removing out-edges from headers in the search queue.
+            // Repeat until the queue is empty.
+            while(searchQueue.TryDequeue(out int index))
+            {
+                topologicalOrder.Add(index);
+                foreach(int depIndex in indexToDependency[index])
+                {
+                    regClassIncludedCount[depIndex]--;
+                    if (regClassIncludedCount[depIndex] == 0)
+                        searchQueue.Enqueue(depIndex);
+                }
+            }
+            // Step 3.3: Verify if there are any cycles left. If so, output all headers that are in a cycle.
+            // It is impossible to find a valid include sequence if there are cycles between reg class headers, so we throw.
+            StringBuilder cycleList = new StringBuilder();
+            foreach (int index in regClassHeaderIndices)
+            {
+                if (regClassIncludedCount[index] != 0)
+                    cycleList.AppendLine(indexToHeader[index].IncludeName); 
+            }
+            if(cycleList.Length > 0)
+            {
+                throw new Exception($"Detected circular dependency! Check the following headers:\n{cycleList}");
+            }
+            // Step 4: Output the include order as the reverse topological order.
+            StringBuilder result = new StringBuilder();
+            // We use the templated LINQ version of Reverse to iterate over topological order in reverse.
+            foreach(int index in topologicalOrder.Reverse<int>())
+            {
+                result.Append($"#include \".generated/{indexToHeader[index].IncludeName}.generated.h\"\n");
+            }
+            return result.ToString();
+        }
+    }
+}

--- a/source/RegAutomation/Program.cs
+++ b/source/RegAutomation/Program.cs
@@ -97,6 +97,7 @@ namespace RegAutomation
                 {
                     // Headers
                     Pattern_Comment.ProcessHeader(h);
+                    Pattern_Include.ProcessHeader(h);
                     Pattern_Class.ProcessHeader(h);
                     
                     // Types
@@ -130,7 +131,7 @@ namespace RegAutomation
                         return;
                     
                     string content = template;
-                    Pattern_Class.GenerateIncludes(header, content, out string includes);
+                    Pattern_Include.GenerateIncludes(header, content, out string includes);
                     
                     StringBuilder bindClassMethods = new StringBuilder();
                     StringBuilder injects = new StringBuilder();
@@ -178,7 +179,7 @@ namespace RegAutomation
             try
             {
                 // Create reg and include code
-                GenerateFile("reg_incl.generated.h", Pattern_Class.GetIncl());
+                GenerateFile("reg_incl.generated.h", Pattern_Include.GetIncl());
                 GenerateFile("reg_init.generated.h", Pattern_Class.GetReg());
                 GenerateFile("reg_deinit.generated.h", "");
                 File.SetLastWriteTime("extension.cpp", DateTime.Now);


### PR DESCRIPTION
This PR implements the proposed solution mentioned in #8, ensuring that the codegen outputs a valid include sequence that won't cause REG_CLASS definitions to overlap.

Do note that due to the project's current structure, I was only able to verify that 1) it still works with two REG_CLASS headers and 2) it will detect circular includes between two REG_CLASS headers. When unit testing is set up, I'll add more test cases to ensure the robustness of the algorithm.

Also note that there seems to be other bugs in the master branch at the moment (namely the class name doesn't seem to be getting parsed correctly?), so I chose not to merge on my end for now. I've removed the dependency on Pattern.FindMatches from Pattern_Include to make the merge easier in the future.

---

The algorithm is implemented in the new `Pattern_Include` class, and works in four steps:
1. Headers and their dependencies are reorganized and assigned a zero-based indexing.
2. A new directed graph that only consists of headers with REG_CLASS is extracted. Essentially non-REG_CLASS headers are skipped, but the indirect include relationships between REG_CLASS headers are preserved.
3. The topological ordering of this new graph is computed using Kahn's algorithm. We can detect circular includes here and throw an exception, as in such cases it's impossible to generate a valid sequence.
4. Use the reverse of the topological ordering as the correct include order.